### PR TITLE
fix CI to use correct julia version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.4.0]
+        julia-version: [1.4]
         julia-arch: [x86]
         os: [ubuntu-latest]
     steps:
@@ -24,7 +24,7 @@ jobs:
       - name: setup julia
         uses: julia-actions/setup-julia@v1.1
         with:
-          version: 1.3.0
+          version:  ${{ matrix.julia-version }}
       - name: Install dependencies
         uses: julia-actions/julia-buildpkg@master
         #run: julia --project=test -e 'using Pkg; Pkg.instantiate()'


### PR DESCRIPTION
Note that I would also recommend using `x64` are your architecture and an Ubuntu LTS (e.g. `ubuntu-18.04`_ as the OS.