### PR TITLE
LMM+timeexpansion coeftable output broken

### DIFF
--- a/src/condense.jl
+++ b/src/condense.jl
@@ -14,8 +14,12 @@ function get_coefnames(uf::UnfoldLinearMixedModelContinuousTime)
     # special case here, because we have to reorder the random effects to the end, else labels get messed up as we concat (coefs,ranefs)
  #   coefnames = Unfold.coefnames(formula(uf))
 #    coefnames(formula(uf)[1].rhs[1])
-    fe_coefnames = vcat([coefnames(f.rhs[1]) for f in formula(uf)]...)
-    re_coefnames = vcat([coefnames(f.rhs[2:end]) for f in formula(uf)]...)
+    formulas = formula(uf)
+    if !isa(formulas,AbstractArray) # in case we have only a single basisfunction
+        formulas = [formulas]
+    end
+    fe_coefnames = vcat([coefnames(f.rhs[1]) for f in formulas]...)
+    re_coefnames = vcat([coefnames(f.rhs[2:end]) for f in formulas]...)
     return vcat(fe_coefnames,re_coefnames)
 end
     

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -335,6 +335,7 @@ end
 ## Condense check for multi channel, multi 
 @testset "LMM multi channel, multi basisfunction" begin
     data,evts = loadtestdata("testCase3", dataPath = (@__DIR__) * "/data")
+    transform!(evts,:subject=>categorical=>:subject);
     data = hcat(data,data)
 
 	bA0 = firbasis(τ=(-0.0,0.1),sfreq=10,name="bA0")

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -334,7 +334,7 @@ end
 
 ## Condense check for multi channel, multi 
 @testset "LMM multi channel, multi basisfunction" begin
-    data,evts = loadtestdata("testCase3")
+    data,evts = loadtestdata("testCase3", dataPath = (@__DIR__) * "/data")
     data = hcat(data,data)
 
 	bA0 = firbasis(τ=(-0.0,0.1),sfreq=10,name="bA0")
@@ -343,8 +343,8 @@ end
 	fA0 = @formula 0~1+condB + zerocorr(1|subject)
 	fA1  =@formula 0~1+condB + zerocorr(1|subject2)
 	m = fit(UnfoldModel,
-		Dict(0=>(fA0,bA0),
-			 1=>(fA1,bA1)),
+		Dict(0=>(fA0,bA0)),
+			# 1=>(fA1,bA1)),
 		evts,data,eventcolumn="condA")
 
 	res = coeftable(m)

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -336,7 +336,7 @@ end
 @testset "LMM multi channel, multi basisfunction" begin
     data,evts = loadtestdata("testCase3", dataPath = (@__DIR__) * "/data")
     transform!(evts,:subject=>categorical=>:subject);
-    data = hcat(data,data)
+    data = hcat(data',data')
 
 	bA0 = firbasis(τ=(-0.0,0.1),sfreq=10,name="bA0")
 	bA1 = firbasis(τ=(0.1,0.2),sfreq=10,name="bA1")

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -332,6 +332,26 @@ if 1 == 0
 
 end
 
+## Condense check for multi channel, multi 
+@testset "LMM multi channel, multi basisfunction" begin
+    data,evts = loadtestdata("testCase3")
+    data = hcat(data,data)
+
+	bA0 = firbasis(τ=(-0.0,0.1),sfreq=10,name="bA0")
+	bA1 = firbasis(τ=(0.1,0.2),sfreq=10,name="bA1")
+	evts.subject2 = evts.subject
+	fA0 = @formula 0~1+condB + zerocorr(1|subject)
+	fA1  =@formula 0~1+condB + zerocorr(1|subject2)
+	m = fit(UnfoldModel,
+		Dict(0=>(fA0,bA0),
+			 1=>(fA1,bA1)),
+		evts,data,eventcolumn="condA")
+
+	res = coeftable(m)
+
+    @test all(last(.!isnothing.(res.group),8))
+    @test all(last(res.coefname,8).=="(Intercept)")
+end
 
 ##------
 


### PR DESCRIPTION
the trouble was that the :estimate was calculated as vcat(coef,ranef),thus over basisfunctions.
 but the coefnames/groupings etc. were done basiswise, i.e. vcat(coefA,ranefA,coefB,ranefB)

This is fixed now by generating the coefnames/groupings also fixef first then ranef
