### PR TITLE
multiEventMassUnivariate

### DIFF
--- a/src/Unfold.jl
+++ b/src/Unfold.jl
@@ -36,8 +36,9 @@ import MixedModels.likelihoodratiotest
 import Base.(+) # overwrite for DesignMatrices
 using Distributions: Gamma, pdf # TODO replace this with direct implementation (used in basisfunction.jl)
 
-include("linearmodels.jl")
+include("typedefinitions.jl")
 include("basisfunctions.jl")
+include("timeexpandedterm.jl")
 include("designmatrix.jl")
 include("fit.jl")
 include("utilities.jl")
@@ -47,6 +48,7 @@ include("predict.jl")
 include("splinepredictors.jl")
 include("effects.jl")
 include("statistics.jl")
+
 #include("plot.jl") # don't include for now
 export fit, fit!, designmatrix!
 export firbasis, hrfbasis, condense_long

--- a/src/condense.jl
+++ b/src/condense.jl
@@ -88,7 +88,23 @@ function StatsModels.coeftable(uf::Union{UnfoldLinearModel,UnfoldLinearMixedMode
     coefs_rep = permutedims(repeat(coefnames, outer = [1, nchan, ncols]), [2, 3, 1])
     colnames_basis_rep = permutedims(repeat(colnames_basis, 1, nchan, ncoefs), [2 1 3])
     chan_rep = repeat(1:nchan, 1, ncols, ncoefs)
-    basisnames_rep = repeat(["mass-univariate"], nchan, ncols, ncoefs)
+
+    designkeys =  collect(keys(design(uf)))
+
+    
+  
+    
+    if length(designkeys) == 1
+        # in case of 1 event, repeat it by ncoefs
+        basisnames = repeat(["event: $(designkeys[1])"],ncoefs)
+    else
+        basisnames = String[]
+        for (ix,evt) = enumerate(designkeys)
+            push!(basisnames,repeat(["event: $(evt)"],size(modelmatrix(uf)[ix],2) )...)
+        end
+    end
+    
+    basisnames_rep = permutedims(repeat(basisnames,1, nchan, ncols),[2,3,1])
     #
     results =
         make_long_df(uf, coefs_rep, chan_rep, colnames_basis_rep, basisnames_rep, :time)

--- a/src/effects.jl
+++ b/src/effects.jl
@@ -32,8 +32,9 @@ function effects(design::AbstractDict, model::UnfoldModel;typical=mean)
 
     # replace non-specified fields with "constants"
     m = modelmatrix(model,false) # get the modelmatrix without timeexpansion
+    @debug "type form[1]",typeof(form[1])
     form_typical = _typify(reference_grid,form,m,typical)
-
+    @debug "type form_typical[1]", typeof(form_typical[1])
     eff = yhat(model,form_typical,reference_grid)
     
     # because coefficients are 2D/3D arry, we have to cast it correctly to one big dataframe
@@ -63,14 +64,14 @@ function effects(design::AbstractDict, model::UnfoldModel;typical=mean)
 return result   
 end
  
- Effects.typify(reference_grid,form::Matrix,X;kwargs...) = typify.(Ref(reference_grid),form,Ref(X);kwargs...)
+ Effects.typify(reference_grid,form::AbstractArray,X;kwargs...) = typify.(Ref(reference_grid),form,Ref(X);kwargs...)
  
 
  # cast single form to a vector
 _typify(reference_grid,form::FormulaTerm{<:InterceptTerm,<:Unfold.TimeExpandedTerm},m,typical) = _typify(reference_grid,[form],[m],typical)
 
-function _typify(reference_grid, form::AbstractArray{<:FormulaTerm{<:Union{<:InterceptTerm,<:Unfold.TimeExpandedTerm}}},m::AbstractSparseArray,typical)
-    
+function _typify(reference_grid, form::AbstractArray{FormulaTerm{<:InterceptTerm,<:Unfold.TimeExpandedTerm}},m::Vector{<:Matrix},typical)
+    @debug "_typify - stripping away timeexpandedterm"
     form_typical = Array{Any}(undef,1, length(form))
     for f = 1:length(form)
         
@@ -90,13 +91,14 @@ function _typify(reference_grid, form::AbstractArray{<:FormulaTerm{<:Union{<:Int
     return form_typical
  end
  function _typify(reference_grid,form::FormulaTerm,m,typical)
+    
     return [typify(reference_grid, form, m; typical=typical)]
 
  end
 
  function _typify(reference_grid,form::AbstractArray{<:FormulaTerm},m::Vector{<:Matrix},typical)
     # Mass Univariate with multiple effects
-    
+    @debug "_typify going the mass univariate route"
     out = []
     for k = 1:length(form)
         push!(out,typify(reference_grid, form[k], m[k]; typical=typical))

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -105,6 +105,7 @@ function designToModeltype(design)
     return UnfoldModelType
 end
 
+
 # helper function for 1 channel data
 function StatsModels.fit(
     UnfoldModelType::Type{T},
@@ -114,7 +115,6 @@ function StatsModels.fit(
     args...;
     kwargs...,
 ) where {T<:Union{<:UnfoldModel}}
-
     @debug("data array is size (X,), reshaping to (1,X)")
     data = reshape(data, 1, :)
     return fit(UnfoldModelType, design, tbl, data, args...; kwargs...)
@@ -274,6 +274,7 @@ function StatsModels.fit!(
     @assert ~isempty(designmatrix(uf))
     @assert typeof(first(values(design(uf)))[1]) <: FormulaTerm "InputError in design(uf) - :key=>(FORMULA,basis/times), formula not found. Maybe formula wasn't at the first place?"
     @assert (typeof(first(values(design(uf)))[2]) <: AbstractVector) ⊻ (typeof(uf) <: UnfoldLinearModelContinuousTime) "InputError: Either a basis function was declared, but a UnfoldLinearModel was built, or a times-vector (and no basis function) was given, but a UnfoldLinearModelContinuousTime was asked for."
+    @assert length(first(values(design(uf)))[2]) == size(data,length(size(data))) "Times Vector does not match last dimension of input data - forgot to epoch?"
 
     to = get_timer("Shared")
 

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -274,7 +274,7 @@ function StatsModels.fit!(
     @assert ~isempty(designmatrix(uf))
     @assert typeof(first(values(design(uf)))[1]) <: FormulaTerm "InputError in design(uf) - :key=>(FORMULA,basis/times), formula not found. Maybe formula wasn't at the first place?"
     @assert (typeof(first(values(design(uf)))[2]) <: AbstractVector) ⊻ (typeof(uf) <: UnfoldLinearModelContinuousTime) "InputError: Either a basis function was declared, but a UnfoldLinearModel was built, or a times-vector (and no basis function) was given, but a UnfoldLinearModelContinuousTime was asked for."
-    @assert length(first(values(design(uf)))[2]) == size(data,length(size(data))) "Times Vector does not match last dimension of input data - forgot to epoch?"
+    @assert length(first(values(design(uf)))[2]) == size(data,length(size(data)-1)) "Times Vector does not match second last dimension of input data - forgot to epoch?"
 
     to = get_timer("Shared")
 

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -274,8 +274,9 @@ function StatsModels.fit!(
     @assert ~isempty(designmatrix(uf))
     @assert typeof(first(values(design(uf)))[1]) <: FormulaTerm "InputError in design(uf) - :key=>(FORMULA,basis/times), formula not found. Maybe formula wasn't at the first place?"
     @assert (typeof(first(values(design(uf)))[2]) <: AbstractVector) ⊻ (typeof(uf) <: UnfoldLinearModelContinuousTime) "InputError: Either a basis function was declared, but a UnfoldLinearModel was built, or a times-vector (and no basis function) was given, but a UnfoldLinearModelContinuousTime was asked for."
+    if isa(uf,UnfoldLinearModel)
     @assert length(first(values(design(uf)))[2]) == size(data,length(size(data))-1) "Times Vector does not match second last dimension of input data - forgot to epoch?"
-
+    end
     to = get_timer("Shared")
 
     @timeit to "modelmatrix" X = modelmatrix(uf)

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -274,7 +274,7 @@ function StatsModels.fit!(
     @assert ~isempty(designmatrix(uf))
     @assert typeof(first(values(design(uf)))[1]) <: FormulaTerm "InputError in design(uf) - :key=>(FORMULA,basis/times), formula not found. Maybe formula wasn't at the first place?"
     @assert (typeof(first(values(design(uf)))[2]) <: AbstractVector) ⊻ (typeof(uf) <: UnfoldLinearModelContinuousTime) "InputError: Either a basis function was declared, but a UnfoldLinearModel was built, or a times-vector (and no basis function) was given, but a UnfoldLinearModelContinuousTime was asked for."
-    @assert length(first(values(design(uf)))[2]) == size(data,length(size(data)-1)) "Times Vector does not match second last dimension of input data - forgot to epoch?"
+    @assert length(first(values(design(uf)))[2]) == size(data,length(size(data))-1) "Times Vector does not match second last dimension of input data - forgot to epoch?"
 
     to = get_timer("Shared")
 

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -13,7 +13,7 @@ function StatsBase.predict(model::UnfoldModel, events)
     end
     if typeof(model) == UnfoldLinearModel
         eff = yhat(model,formulas[1],newevents)
-        timesVec = gen_timeev(times(model)[1],size(newevents, 1)) # XXX needs to be modified to make automatic multi-event
+        timesVec = gen_timeev(times(model),size(newevents, 1)) 
     else
         fromTo,timesVec,eff = yhat(model,formulas,newevents) 
     end

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -93,7 +93,7 @@ function solver_default(
     beta = zeros(Union{Missing,Number},size(data, 1), size(data, 2), size(X, 2))
     @showprogress 0.1 for ch = 1:size(data, 1)
         for t = 1:size(data, 2)
-            @debug("$(ndims(data,)),$t,$ch")
+#            @debug("$(ndims(data,)),$t,$ch")
             
             dd = view(data, ch, t,:)
             ix = @. !ismissing(dd)

--- a/src/timeexpandedterm.jl
+++ b/src/timeexpandedterm.jl
@@ -1,0 +1,53 @@
+"""
+Object with a *term* and an applicable *BasisFunction* and a eventfield that are later passed to the basisfunction.
+
+$(TYPEDEF)
+$(TYPEDSIGNATURES)
+$(FIELDS)
+# Examples
+```julia-repl
+julia>  b = TimeExpandedTerm(term,kernel,[:latencyTR,:durationTR])
+```
+"""
+struct TimeExpandedTerm{T<:AbstractTerm} <: AbstractTerm 
+    "Term that the basis function is applied to. This is regularly called in other functions to get e.g. term-coefnames and timeexpand those"
+    term::T
+    "Kernel that determines what should happen to the designmatrix of the term"
+    basisfunction::BasisFunction
+    "Which fields of the event-table should be passed to the basisfunction.Important: The first entry has to be the event-latency in samples!"
+    eventfields::Array{Symbol}
+end
+
+
+function TimeExpandedTerm(
+    term::NTuple{N,Union{<:AbstractTerm,<:MixedModels.RandomEffectsTerm}},
+    basisfunction,
+    eventfields::Array{Symbol,1},
+) where {N}
+    # for mixed models, apply it to each Term
+    TimeExpandedTerm.(term, Ref(basisfunction), Ref(eventfields))
+end
+function TimeExpandedTerm(term, basisfunction, eventfields::Nothing)
+    # if the eventfield is nothing, call default
+    TimeExpandedTerm(term, basisfunction)
+end
+
+function TimeExpandedTerm(term, basisfunction, eventfields::Symbol)
+    # call with symbol, convert to array of symbol
+    TimeExpandedTerm(term, basisfunction, [eventfields])
+end
+
+function TimeExpandedTerm(term, basisfunction; eventfields = [:latency])
+    # default call, use latency
+    TimeExpandedTerm(term, basisfunction, eventfields)
+end
+
+collabel(term::TimeExpandedTerm) = collabel(term.basisfunction)
+StatsModels.width(term::TimeExpandedTerm) = width(term.basisfunction)
+StatsModels.terms(t::TimeExpandedTerm) = terms(t.term)
+
+function Base.show(io::IO, p::TimeExpandedTerm)
+    #print(io, "timeexpand($(p.term), $(p.basisfunction.type),$(p.basisfunction.times))")
+    println(io, "$(coefnames(p))")
+end
+

--- a/src/typedefinitions.jl
+++ b/src/typedefinitions.jl
@@ -1,4 +1,3 @@
-
 struct DesignMatrix
     "Array of formulas"
     formulas::Any

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -93,9 +93,9 @@ end
 $(SIGNATURES)
 Flatten a 1D array from of a 2D/3D array. Also drops the empty dimension
 """
-function linearize(x::AbstractArray)
+function linearize(x::AbstractArray{T,N}) where {T,N}
     # used in condense_long to generate the long format
-    return dropdims(reshape(x, :, 1), dims = 2)
+    return dropdims(reshape(x, :, 1), dims = 2)::AbstractArray{T,1}
 end
 function linearize(x::String)
     return x
@@ -130,13 +130,13 @@ end
 
 function zeropad(X, data::AbstractArray{T,3}) where {T<:Union{Missing,<:Number}}
     @debug("3d zeropad")
-    if size(X, 1) > size(data, 3)
-        X = X[1:size(data, 3), :]
-    else
-        data = data[:, :, 1:size(X, 1)]
-    end
+    
+    @assert size(X, 1) == size(data, 3) "Your events are not of the same size as your last dimension of data"
+        
     return X, data
 end
+
+
 
 function clean_data(
     data::AbstractArray{T,2},

--- a/test/effects.jl
+++ b/test/effects.jl
@@ -1,5 +1,3 @@
-include("test_utilities.jl")
-
 data, evts = loadtestdata("test_case_3a") #
 
 data_r = reshape(data, (1, :))

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -1,4 +1,3 @@
-
 data, evts = loadtestdata("test_case_3a") #
 f = @formula 0 ~ 1 + conditionA + continuousA # 1
 
@@ -22,6 +21,24 @@ data_e, times = Unfold.epoch(data = data_r, tbl = evts, τ = (-1.0, 1.9), sfreq 
 
 end
 
+@testset "epoched auto multi-event" begin
+    
+    evts_local = deepcopy(evts)
+    evts_local.type .= repeat(["A","B"],nrow(evts)÷2)
+
+    uf = fit(UnfoldModel, Dict("A" => (f, times)),evts_local,data_e;eventcolumn="type")
+    @test size(coef(uf)) == (2,59,3)
+    uf_2events = fit(UnfoldModel, Dict("A" => (f, times),"B"=>(@formula(0~1),times)),evts_local,data_e;eventcolumn="type")
+    @test size(coef(uf_2events)) == (2,59,4)
+
+    c = coeftable(uf)
+    c2 = coeftable(uf_2events)
+    @test c2[c2.basisname .== "event: A",:] == c
+
+    e_uf2 = effects(Dict(:condtionA=>[0,1]),uf_2events)
+    e_uf = effects(Dict(:condtionA=>[0,1]),uf)
+    
+end
 
 @testset "test Autodetection" begin
     @test Unfold.designToModeltype(Dict(Any => (@formula(0 ~ 1), 0:10))) == UnfoldLinearModel
@@ -255,8 +272,7 @@ end
     # cut the data into epochs
     # TODO This ignores subject bounds
     data_e, times = Unfold.epoch(data = data, tbl = evts, τ = (-1.0, 1.9), sfreq = 10)
-    data_missing_e, times =
-        Unfold.epoch(data = data_missing, tbl = evts, τ = (-1.0, 1.9), sfreq = 10)
+    data_missing_e, times =        Unfold.epoch(data = data_missing, tbl = evts, τ = (-1.0, 1.9), sfreq = 10)
     evts_e, data_e = Unfold.dropMissingEpochs(copy(evts), data_e)
     evts_missing_e, data_missing_e = Unfold.dropMissingEpochs(copy(evts), data_missing_e)
 

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -312,7 +312,7 @@ end
 
 
     # Timexpanded Univariate Mixed
-    f = @formula 0 ~ 1 + condA + condB + (1 + condA + condB | subject)
+    f = @formula 0 ~ 1 + condA + condB + (1 + condA | subject)
     basisfunction = firbasis(τ = (-0.2, 0.3), sfreq = 10, name = "ABC")
     @time m_tum = fit(
         UnfoldModel,


### PR DESCRIPTION
finally we can do 
Dict(:A=>(f1,times),:B=>(f2,times))

for mass univariate models :

- additional assertion that MassUnivariate must match data
- fix that previous assertion
- fix2 that previous assertion
- make assertion local to only UfoldModels
- multi event support for mass univaraite mdels
- speed up a test
