### PR TITLE
Remove spaces between docstring and effect function

### DIFF
--- a/src/effects.jl
+++ b/src/effects.jl
@@ -11,20 +11,19 @@ using Effects
 """
     effects(design::AbstractDict, model::UnfoldModel; typical = mean)
 
-Calculates marginal effects for all term-combinations in `design`.
+Calculates marginal effects for all term combinations in `design`.
 
- Implementation based on Effects Package; likely could repackage in UnfoldEffects; somebody wants to do it? This would make it easier to cross-maintain it to changes/bugfixes in the Effects.jl Package
- `design` is a Dictionary containing those predictors (as keys) with levels (as values), that you want to evaluate. The `typical` refers to the value, that other predictors not in the Dictionary should take on.
-
+Implementation based on Effects.jl package; likely could repackage in UnfoldEffects.jl; somebody wants to do it? This would make it easier to cross-maintain it to changes/bug fixes in the Effects.jl package.
+`design` is a dictionary containing those predictors (as keys) with levels (as values), that you want to evaluate. The `typical` refers to the value, which other predictors that are not specified in the dictionary, should take on.
 
 For MixedModels, the returned effects are based on the "typical" subject, i.e. all random effects are put to 0.
 
  # Example
  ```julia-repl
  julia> f = @formula 0 ~ categoricalA + continuousA + continuousB
- julia> uf = fit(UnfoldModel,(Any=>(f,times)),data,events)
- julia> d = Dict(:categoricalA=>["levelA","levelB"],:continuousB=>[-2,0,2])
- julia> effects(d,uf)
+ julia> uf = fit(UnfoldModel, (Any => (f, times)), data, events)
+ julia> d = Dict(:categorical => ["levelA", "levelB"], :continuous => [-2, 0, 2])
+ julia> effects(d, uf)
 ```
  will result in 6 predicted values: A/-2, A/0, A/2, B/-2, B/0, B/2.
 """

--- a/src/effects.jl
+++ b/src/effects.jl
@@ -30,7 +30,7 @@ For MixedModels, the returned effects are based on the "typical" subject, i.e. a
 """
 function effects(design::AbstractDict, model::T; typical = mean) where {T<:UnfoldModel}
     if isempty(design)
-        return effects(Dict(:dummy=>[:dummy]),model;typical)
+        return effects(Dict(:dummy => [:dummy]), model; typical)
     end
     reference_grid = expand_grid(design)
     form = Unfold.formulas(model) # get formula

--- a/src/effects.jl
+++ b/src/effects.jl
@@ -28,8 +28,6 @@ For MixedModels, the returned effects are based on the "typical" subject, i.e. a
 ```
  will result in 6 predicted values: A/-2, A/0, A/2, B/-2, B/0, B/2.
 """
-
-
 function effects(design::AbstractDict, model::T; typical = mean) where {T<:UnfoldModel}
     if isempty(design)
         return effects(Dict(:dummy=>[:dummy]),model;typical)

--- a/src/effects.jl
+++ b/src/effects.jl
@@ -9,7 +9,7 @@ using Effects
 
 
 """
-effects(design::AbstractDict, model::UnfoldModel;typical=mean)
+    effects(design::AbstractDict, model::UnfoldModel; typical = mean)
 
 Calculates marginal effects for all term-combinations in `design`.
 


### PR DESCRIPTION
The docstring for the `effects` function is currently not recognized because there are empty lines between the docstring and the function. I removed them.